### PR TITLE
LRAC-5749 - [AC - Events] - Batches should not be dropped from the queue due to time constraints

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/messageQueue.js
+++ b/modules/apps/analytics/analytics-client-js/src/messageQueue.js
@@ -21,9 +21,6 @@ import {
 import {getRetryDelay} from './utils/delay';
 import {getItem, setItem, verifyStorageLimitForKey} from './utils/storage';
 
-const MIN_DELAY = 1000;
-const MAX_DELAY = 30000;
-
 /**
  * An Analytics Event.
  *
@@ -231,9 +228,7 @@ class MessageQueue {
 				{
 					attemptNumber,
 					item,
-					time:
-						now +
-						getRetryDelay(attemptNumber, MIN_DELAY, MAX_DELAY),
+					time: now + getRetryDelay(attemptNumber, this.maxRetries),
 				},
 				false
 			);

--- a/modules/apps/analytics/analytics-client-js/src/messageQueue.js
+++ b/modules/apps/analytics/analytics-client-js/src/messageQueue.js
@@ -221,18 +221,15 @@ class MessageQueue {
 	 * @param {Number} attemptNumber - The number of attempts to process this item.
 	 */
 	_requeue(item, attemptNumber) {
-		const now = Date.now();
-
-		if (attemptNumber < this.maxRetries) {
-			this._enqueue(
-				{
-					attemptNumber,
-					item,
-					time: now + getRetryDelay(attemptNumber, this.maxRetries),
-				},
-				false
-			);
-		}
+		this._enqueue(
+			{
+				attemptNumber,
+				item,
+				time:
+					Date.now() + getRetryDelay(attemptNumber, this.maxRetries),
+			},
+			false
+		);
 	}
 
 	/**

--- a/modules/apps/analytics/analytics-client-js/src/utils/delay.js
+++ b/modules/apps/analytics/analytics-client-js/src/utils/delay.js
@@ -17,10 +17,17 @@
  * by a miniumum and maximum value.
  *
  * @param {Number} attemptNumber - The current attempt number.
+ * @param {Number} maxAttempts - The maximum number of attempts to limit delay increase.
  * @returns {Number} - Retry delay in milliseconds.
  */
-export const getRetryDelay = (attemptNumber, min, max) => {
-	const ms = min * Math.pow(2, attemptNumber);
-
-	return Math.min(ms, max);
+export const getRetryDelay = (attemptNumber, maxAttempts) => {
+	return fib(Math.min(attemptNumber, maxAttempts)) * 1000;
 };
+
+/**
+ * Get Fibonnaci number.
+ *
+ * @param {Number} n - The position in Fibonnaci sequence.
+ * @returns {Number} - Fibonnaci value at nth position.
+ */
+export const fib = n => (n <= 1 ? 1 : fib(n - 1) + fib(n - 2));

--- a/modules/apps/analytics/analytics-client-js/test/messageQueue.js
+++ b/modules/apps/analytics/analytics-client-js/test/messageQueue.js
@@ -14,7 +14,6 @@
 
 import MessageQueue from '../src/messageQueue';
 import {STORAGE_KEY_MESSAGES} from '../src/utils/constants';
-import * as delayUtils from '../src/utils/delay';
 import {setItem} from '../src/utils/storage';
 import {getDummyEvent, wait} from './helpers';
 
@@ -89,22 +88,6 @@ describe('MessageQueue', () => {
 		await wait(PROCESS_DELAY * 1.1);
 
 		expect(messageQueue.getMessages().length).toEqual(0);
-	});
-
-	it('stops trying to process a message after a maximum amount of retries', async () => {
-		const spy = jest
-			.spyOn(delayUtils, 'getRetryDelay')
-			.mockImplementation(() => 0);
-
-		messageQueue.processFn = getProcessFn(false);
-
-		await messageQueue.addItem(getMockMessageItem('test-4'));
-
-		await wait(PROCESS_DELAY * 2.1);
-
-		expect(messageQueue.getMessages().length).toEqual(0);
-
-		spy.mockRestore();
 	});
 
 	it('requeues an item with a scheduled execution delay after failing to process it', async () => {

--- a/modules/apps/analytics/analytics-client-js/test/utils/delay.js
+++ b/modules/apps/analytics/analytics-client-js/test/utils/delay.js
@@ -12,15 +12,18 @@
  * details.
  */
 
+import {LIMIT_FAILED_ATTEMPTS} from '../../src/utils/constants';
 import {getRetryDelay} from '../../src/utils/delay';
 
 describe('getRetryDelay', () => {
-	it('returns a delay as a function of attempt number and min/max delay', () => {
-		const min = 1000;
-		const max = 30000;
-
-		expect(getRetryDelay(1, min, max)).toEqual(2000);
-		expect(getRetryDelay(2, min, max)).toEqual(4000);
-		expect(getRetryDelay(30, min, max)).toEqual(max);
+	it('returns a delay as a function of attempt number with a maximum delay', () => {
+		expect(getRetryDelay(1, LIMIT_FAILED_ATTEMPTS)).toEqual(1000);
+		expect(getRetryDelay(2, LIMIT_FAILED_ATTEMPTS)).toEqual(2000);
+		expect(getRetryDelay(3, LIMIT_FAILED_ATTEMPTS)).toEqual(3000);
+		expect(getRetryDelay(4, LIMIT_FAILED_ATTEMPTS)).toEqual(5000);
+		expect(getRetryDelay(5, LIMIT_FAILED_ATTEMPTS)).toEqual(8000);
+		expect(getRetryDelay(6, LIMIT_FAILED_ATTEMPTS)).toEqual(13000);
+		expect(getRetryDelay(7, LIMIT_FAILED_ATTEMPTS)).toEqual(21000);
+		expect(getRetryDelay(30, LIMIT_FAILED_ATTEMPTS)).toEqual(21000);
 	});
 });


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-5749